### PR TITLE
Feat/api retry and minor bug fixes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        implementation 'io.linkrunner:android-sdk:2.1.5'
+        implementation 'io.linkrunner:android-sdk:3.0.0'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        implementation 'io.linkrunner:android-sdk:3.0.0'
+        implementation 'io.linkrunner:android-sdk:3.0.1'
     }
 }
 

--- a/ios/linkrunner.podspec
+++ b/ios/linkrunner.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'linkrunner'
-  s.version          = '3.0.1'
+  s.version          = '4.0.0'
   s.summary          = 'Flutter Package for linkrunner, track every click, download and dropoff for your app links'
   s.description      = <<-DESC
 Flutter Package for linkrunner.io - Advanced app attribution and link tracking service. 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -11,7 +11,7 @@ import 'models/lr_user_data.dart';
 class LinkRunner {
   static final LinkRunner _singleton = LinkRunner._internal();
 
-  final String packageVersion = '3.0.1';
+  final String packageVersion = '4.0.0';
 
   String? token;
 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -44,7 +44,14 @@ class LinkRunner {
     this.token = token;
     
     try {
-      await LinkRunnerNativeBridge.init(token, secretKey, keyId, debug);
+      await LinkRunnerNativeBridge.init(
+        token,
+        secretKey,
+        keyId,
+        debug,
+        'FLUTTER',
+        packageVersion,
+      );
     } catch (e) {
       developer.log('Failed to initialize SDK: $e');
     }

--- a/lib/linkrunner_native_bridge.dart
+++ b/lib/linkrunner_native_bridge.dart
@@ -12,7 +12,15 @@ class LinkRunnerNativeBridge {
   static const MethodChannel _channel = MethodChannel('linkrunner_native');
   
   /// Initialize the native SDK with project token
-  static Future<void> init(String token, String? secretKey, String? keyId, bool debug) async {
+  /// Optionally pass the client SDK platform and version so native Android can be configured before init
+  static Future<void> init(
+    String token,
+    String? secretKey,
+    String? keyId,
+    bool debug, [
+    String platform = 'FLUTTER',
+    String? packageVersion,
+  ]) async {
     try {
       final Map<String, dynamic> arguments = {
         'token': token,
@@ -25,6 +33,11 @@ class LinkRunnerNativeBridge {
       }
       if (keyId != null) {
         arguments['keyId'] = keyId;
+      }
+      // Provide SDK platform and version so Android can call configureSDK before init
+      arguments['platform'] = platform;
+      if (packageVersion != null) {
+        arguments['packageVersion'] = packageVersion;
       }
       
       var res = await _channel.invokeMethod('init', arguments);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 3.0.1
+version: 4.0.0
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"


### PR DESCRIPTION
Requires linkrunner-android sdk version `3.0.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Initialization now sends platform identifier and package version to the native SDK for improved diagnostics and compatibility. Automatically configures the SDK before completing init. No changes required for existing integrations.

- Chores
  - Updated Android SDK dependency to 3.0.1 for improved stability.
  - Bumped package version to 4.0.0 and updated iOS podspec accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->