### PR TITLE
chore: bump native android sdk to 3.8.1 (flutter 3.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.9.1
 
-- Bumped native Android SDK to `io.linkrunner:android-sdk:3.8.1` (encrypted-at-rest credential storage)
+- Bumped native Android SDK to `io.linkrunner:android-sdk:3.8.1` — token, signature key id, and signature secret key are now encrypted at rest in SharedPreferences using AES-256-GCM with a hardware-backed AndroidKeyStore key (StrongBox when available); legacy plaintext keys from prior versions are wiped atomically on the first `init()` after upgrade
 
 ## 3.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.1
+
+- Bumped native Android SDK to `io.linkrunner:android-sdk:3.8.1` (encrypted-at-rest credential storage)
+
 ## 3.9.0
 
 - Added `handleDeeplink()` method for re-engagement attribution tracking

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        implementation 'io.linkrunner:android-sdk:3.8.0'
+        implementation 'io.linkrunner:android-sdk:3.8.1'
     }
 }
 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -12,7 +12,7 @@ import 'models/lr_user_data.dart';
 class LinkRunner {
   static final LinkRunner _singleton = LinkRunner._internal();
 
-  final String packageVersion = '3.9.0';
+  final String packageVersion = '3.9.1';
 
   String? token;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 3.9.0
+version: 3.9.1
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"


### PR DESCRIPTION
## Summary

- Bump `io.linkrunner:android-sdk` from `3.8.0` to `3.8.1` in `android/build.gradle`
- Bump Flutter package version from `3.9.0` to `3.9.1` in `pubspec.yaml` and `lib/linkrunner.dart`
- Add `3.9.1` entry to `CHANGELOG.md`

The native SDK 3.8.1 stores `token`, `keyId`, and `secretKey` encrypted-at-rest with AES-256-GCM backed by AndroidKeyStore, replacing the previous plaintext SharedPreferences storage. Migration from legacy plaintext keys to the new V2 encrypted keys happens atomically on first `init()` after the upgrade — no user action required.

## Test plan

- [x] Verified on a vivo I1928 (Android 12) running the playground app: V2 encrypted keys present, legacy plaintext keys absent, ciphertext lengths match expected AES-GCM overhead (12-byte IV + plaintext + 16-byte tag, base64-encoded)
- [ ] Smoke test: install attribution, signup, capturePayment, trackEvent, handleDeeplink still flow through to `api.linkrunner.io` with HTTP 202
- [ ] Upgrade-path test: install an older build that wrote plaintext keys, then upgrade to this build and confirm legacy keys are wiped on the first `init()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 3.9.1.
  * Updated native Android SDK to version 3.8.1, adding encrypted-at-rest credential storage support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->