### PR TITLE
feat: make payment_id mandatory for capturePayment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 3.10.0
+## 4.0.0
 
 - **Breaking:** `paymentId` is now required in `capturePayment`; the call throws before dispatch when it is missing
-- Bumped native Android SDK to `io.linkrunner:android-sdk:3.10.0`
-- Bumped native iOS SDK to `LinkrunnerKit 3.12.0`
+- Bumped native Android SDK to `io.linkrunner:android-sdk:4.0.0`
+- Bumped native iOS SDK to `LinkrunnerKit 4.0.0`
 
 ## 3.9.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.10.0
+
+- **Breaking:** `paymentId` is now required in `capturePayment`; the call throws before dispatch when it is missing
+- Bumped native Android SDK to `io.linkrunner:android-sdk:3.10.0`
+- Bumped native iOS SDK to `LinkrunnerKit 3.12.0`
+
 ## 3.9.1
 
 - Bumped native Android SDK to `io.linkrunner:android-sdk:3.8.1` — token, signature key id, and signature secret key are now encrypted at rest in SharedPreferences using AES-256-GCM with a hardware-backed AndroidKeyStore key (StrongBox when available); legacy plaintext keys from prior versions are wiped atomically on the first `init()` after upgrade

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        implementation 'io.linkrunner:android-sdk:3.8.1'
+        implementation 'io.linkrunner:android-sdk:3.10.0'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        implementation 'io.linkrunner:android-sdk:3.10.0'
+        implementation 'io.linkrunner:android-sdk:4.0.0'
     }
 }
 

--- a/ios/linkrunner.podspec
+++ b/ios/linkrunner.podspec
@@ -13,7 +13,7 @@ user event tracking, and payment analytics for Flutter applications.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'LinkrunnerKit', '3.10.0'
+  s.dependency 'LinkrunnerKit', '3.12.0'
   s.platform = :ios, '15.0'
   s.swift_version = '5.9'
 

--- a/ios/linkrunner.podspec
+++ b/ios/linkrunner.podspec
@@ -13,7 +13,7 @@ user event tracking, and payment analytics for Flutter applications.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'LinkrunnerKit', '3.12.0'
+  s.dependency 'LinkrunnerKit', '4.0.0'
   s.platform = :ios, '15.0'
   s.swift_version = '5.9'
 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -12,7 +12,7 @@ import 'models/lr_user_data.dart';
 class LinkRunner {
   static final LinkRunner _singleton = LinkRunner._internal();
 
-  final String packageVersion = '3.9.1';
+  final String packageVersion = '3.10.0';
 
   String? token;
 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -12,7 +12,7 @@ import 'models/lr_user_data.dart';
 class LinkRunner {
   static final LinkRunner _singleton = LinkRunner._internal();
 
-  final String packageVersion = '3.10.0';
+  final String packageVersion = '4.0.0';
 
   String? token;
 

--- a/lib/models/lr_capture_payment.dart
+++ b/lib/models/lr_capture_payment.dart
@@ -32,7 +32,7 @@ class LRCapturePayment {
     this.status,
     this.eventData,
   }) {
-    if (paymentId.isEmpty) {
+    if (paymentId.trim().isEmpty) {
       throw ArgumentError('paymentId must not be empty');
     }
   }

--- a/lib/models/lr_capture_payment.dart
+++ b/lib/models/lr_capture_payment.dart
@@ -17,7 +17,7 @@ enum PaymentStatus {
 }
 
 class LRCapturePayment {
-  final String? paymentId;
+  final String paymentId;
   final String userId;
   final double amount;
   final PaymentType? type;
@@ -25,25 +25,26 @@ class LRCapturePayment {
   final Map<String, dynamic>? eventData;
 
   LRCapturePayment({
-    this.paymentId,
+    required this.paymentId,
     required this.userId,
     required this.amount,
     this.type,
     this.status,
     this.eventData,
-  });
+  }) {
+    if (paymentId.isEmpty) {
+      throw ArgumentError('paymentId must not be empty');
+    }
+  }
 
   Map<String, dynamic> toJSON() {
     Map<String, dynamic> json = {
+      'payment_id': paymentId,
       'user_id': userId,
       'amount': amount,
       'type': type?.name ?? PaymentType.DEFAULT_PAYMENT.name,
       'status': status?.name ?? PaymentStatus.PAYMENT_COMPLETED.name,
     };
-
-    if (paymentId != null) {
-      json['payment_id'] = paymentId;
-    }
 
     if (eventData != null) {
       json['event_data'] = eventData;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 3.9.1
+version: 3.10.0
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 3.10.0
+version: 4.0.0
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"

--- a/test/lr_capture_payment_test.dart
+++ b/test/lr_capture_payment_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linkrunner/models/lr_capture_payment.dart';
+
+void main() {
+  group('LRCapturePayment', () {
+    test('builds and serializes payment_id when provided', () {
+      final payment = LRCapturePayment(
+        paymentId: 'payment_123',
+        userId: 'user_1',
+        amount: 99.99,
+      );
+
+      final json = payment.toJSON();
+
+      expect(payment.paymentId, 'payment_123');
+      expect(json['payment_id'], 'payment_123');
+    });
+
+    test('throws when payment_id is empty', () {
+      expect(
+        () => LRCapturePayment(
+          paymentId: '',
+          userId: 'user_1',
+          amount: 99.99,
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
LRCapturePayment.paymentId is now a required non-null String and throws ArgumentError when empty; payment_id is always serialized. Adds a unit test. removePayment is unchanged.

Refs LIN-1649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment ID is now required and enforced to be non-empty.

* **Tests**
  * Added test coverage for payment ID validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->