### PR TITLE
Release Flutter 4.0.3 with Android SDK 4.0.2 (LIN-1946)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 4.0.3
+
+- Bumped the native Android SDK to `io.linkrunner:android-sdk:4.0.2` to prevent signup from sending an empty install instance ID when it runs concurrently with initialization.
+
 ## 4.0.2
 
 - Fixed `setAdditionalData` on Android by aligning the native bridge argument key with Flutter and iOS.
-- Bumped the native Android SDK to `io.linkrunner:android-sdk:4.0.2` to prevent signup from sending an empty install instance ID when it runs concurrently with initialization.
 
 ## 4.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+
+- Bumped the native Android SDK to `io.linkrunner:android-sdk:4.0.2` to prevent signup from sending an empty install instance ID when it runs concurrently with initialization.
+
 ## 4.0.1
 
 - Exposed ad-network attribution fields in attribution data: `adNetworkCampaignId`, `adSetId`, `adSetName`, `adCreativeId`, `adCreativeName`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        implementation 'io.linkrunner:android-sdk:4.0.1'
+        implementation 'io.linkrunner:android-sdk:4.0.2'
     }
 }
 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -12,7 +12,7 @@ import 'models/lr_user_data.dart';
 class LinkRunner {
   static final LinkRunner _singleton = LinkRunner._internal();
 
-  final String packageVersion = '4.0.1';
+  final String packageVersion = '4.0.2';
 
   String? token;
 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -12,7 +12,7 @@ import 'models/lr_user_data.dart';
 class LinkRunner {
   static final LinkRunner _singleton = LinkRunner._internal();
 
-  final String packageVersion = '4.0.2';
+  final String packageVersion = '4.0.3';
 
   String? token;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 4.0.1
+version: 4.0.2
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 4.0.2
+version: 4.0.3
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"


### PR DESCRIPTION
Linear: https://linear.app/linkrunner/issue/LIN-1946/android-sdk-signup-can-send-empty-install-instance-id-before

## Summary

- merge the published Flutter `4.0.2` additional-data bridge fix from `main`
- bump the Flutter package from `4.0.2` to `4.0.3`
- bump the native Android dependency from `4.0.1` to `4.0.2`
- update the bridge package version and changelog

## Validation

- package version, bridge version, and Android dependency checks passed
- `git diff --check` passed

Android dependency resolution is available after `io.linkrunner:android-sdk:4.0.2` is published.
