### PR TITLE
Fix Flutter Android setAdditionalData bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+
+- Fixed `setAdditionalData` on Android by aligning the native bridge argument key with Flutter and iOS.
+
 ## 4.0.1
 
 - Exposed ad-network attribution fields in attribution data: `adNetworkCampaignId`, `adSetId`, `adSetName`, `adCreativeId`, `adCreativeName`.

--- a/android/src/main/kotlin/io/linkrunner/flutter/LinkrunnerPlugin.kt
+++ b/android/src/main/kotlin/io/linkrunner/flutter/LinkrunnerPlugin.kt
@@ -72,9 +72,9 @@ class LinkrunnerPlugin: FlutterPlugin, MethodCallHandler {
                 }
             }
             "setAdditionalData" -> {
-                val IntegrationData = call.argument<Map<String, Any>>("IntegrationData")
-                if (IntegrationData != null) {
-                    setAdditionalData(IntegrationData, result)
+                val integrationData = call.argument<Map<String, Any>>("integrationData")
+                if (integrationData != null) {
+                    setAdditionalData(integrationData, result)
                 } else {
                     result.error("INVALID_ARGUMENT", "Integration data is required", null)
                 }
@@ -315,14 +315,14 @@ class LinkrunnerPlugin: FlutterPlugin, MethodCallHandler {
         }
     }
 
-    private fun setAdditionalData(IntegrationData: Map<String, Any>, result: Result) {
+    private fun setAdditionalData(integrationData: Map<String, Any>, result: Result) {
         pluginScope.launch {
             try {
-                val IntegrationDataModel = IntegrationData(
-                    clevertapId = IntegrationData["clevertap_id"] as? String
+                val integrationDataModel = IntegrationData(
+                    clevertapId = integrationData["clevertap_id"] as? String
                 )
                 
-                val setAdditionalDataResult = NativeLinkRunner.getInstance().setAdditionalData(IntegrationDataModel)
+                val setAdditionalDataResult = NativeLinkRunner.getInstance().setAdditionalData(integrationDataModel)
                 
                 withContext(Dispatchers.Main) {
                     if (setAdditionalDataResult.isSuccess) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 4.0.1
+version: 4.0.2
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"


### PR DESCRIPTION
## Summary

- align the Flutter Android `setAdditionalData` method-channel argument with the canonical lowercase `integrationData` key used by Dart and iOS
- normalize the affected Kotlin local and parameter names
- bump the Flutter package version to `4.0.2` and document the fix

## Root cause

The Dart bridge sends `integrationData`, but the Android Flutter plugin attempted to read `IntegrationData`. The lookup therefore returned `null` and every Android call failed with `INVALID_ARGUMENT`.

## Impact

Flutter applications on Android can now pass integration identifiers such as `clevertap_id` without a customer code change beyond upgrading the package.

## Validation

- `flutter test` passes
- built and launched `flutter-playground-app` on Android emulator `emulator-5554` using the local `linkrunner` 4.0.2 package
- initialized the SDK successfully
- invoked `setAdditionalData` and confirmed the Android worker received `integrationData={clevertap_id=ct_playground_123}` and sent the integrations request


Linear: https://linear.app/linkrunner/issue/LIN-2092/flutter-sdk-setadditionaldata-always-fails-on-android-integratciondata


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android handling of additional integration data so values are correctly passed through the Flutter bridge.
  * Ensured the CleverTap identifier is properly recognized when setting additional data.

* **Chores**
  * Updated the package version to 4.0.2.
  * Added release notes documenting the Android fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->