### PR TITLE
chore: bump to 4.1.0 with ICM-capable native SDKs [LIN-2078]

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,19 @@
+example/
+.dart_tool/
+.idea/
+.vscode/
+.packages
+.pub/
+build/
+*.iml
+.DS_Store
+.flutter-plugins
+.flutter-plugins-dependencies
+
+# CocoaPods output from local development, not part of the package
+ios/Pods/
+ios/.symlinks/
+
+# Internal working docs
+CLAUDE.md
+CROSS_REFERENCE_ARCHITECTURE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## 4.1.0
 
-- Added support for Google Integrated Conversion Measurement (ICM). On iOS the native SDK now fetches Google's On-Device Measurement value automatically during initialization and forwards it to Linkrunner; no Dart API change is required to adopt it.
-- Bumped native Android SDK to `io.linkrunner:android-sdk:4.1.0` and native iOS SDK to `LinkrunnerKit 4.1.0`.
-- iOS apps now pull `GoogleAdsOnDeviceConversion` transitively and require `-ObjC` and `-lc++` in Other Linker Flags. CocoaPods applies these automatically. If your app also uses Firebase Analytics, check the version compatibility table in the LinkrunnerKit README.
+- Added support for Google Integrated Conversion Measurement (ICM) on iOS. The native SDK fetches Google's On-Device Measurement value during initialization and forwards it to Linkrunner. There is no Dart API to call, but ICM is **opt-in**: it stays inactive until you add Google's SDK to your app (see below). ICM is iOS-only for now; Android is unaffected.
+- **To enable ICM on iOS**, add Google's On-Device Measurement SDK to your app's `ios/Podfile`:
+
+  ```ruby
+  pod 'GoogleAdsOnDeviceConversion'
+  ```
+
+  If your app already uses the Firebase iOS SDK (11.14.0+) you have it and need nothing further. LinkrunnerKit detects the SDK at runtime rather than depending on it, so apps that skip this carry none of its weight — no extra dependency, no size increase. CocoaPods adds the required `-ObjC` and `-lc++` linker flags for you, so Flutter apps have no Build Settings changes to make. To confirm it is live, initialize with `debug: true` and look for `odm_available=true` in the iOS logs; `odm_available=false` means Google's SDK is not linked.
+- Bumped native iOS SDK to `LinkrunnerKit 4.1.0` (ICM plus the consent model) and native Android SDK to `io.linkrunner:android-sdk:4.1.0` (consent model only).
 - Fixed the iOS podspec version, which had drifted to `3.4.0` while `pubspec.yaml` was on `4.0.1`. Both now track the package version.
 - `setConsent(LRConsent(...))` for Google Ads consent: `isEEA`, `hasConsentForDataUsage` and `hasConsentForAdsPersonalization`, each `ConsentStatus.GRANTED` / `.DENIED` / `.UNKNOWN` (field names match the native iOS and Android SDKs; they are sent as `is_eea`, `ad_user_data` and `ad_personalization`). Call it before `init` and again whenever your CMP state changes. Omitted signals default to `.UNKNOWN` and are dropped from the payload rather than sent as a denial. Supported on iOS and Android.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.1.0
+
+- Added support for Google Integrated Conversion Measurement (ICM). On iOS the native SDK now fetches Google's On-Device Measurement value automatically during initialization and forwards it to Linkrunner; no Dart API change is required to adopt it.
+- Bumped native Android SDK to `io.linkrunner:android-sdk:4.1.0` and native iOS SDK to `LinkrunnerKit 4.1.0`.
+- iOS apps now pull `GoogleAdsOnDeviceConversion` transitively and require `-ObjC` and `-lc++` in Other Linker Flags. CocoaPods applies these automatically. If your app also uses Firebase Analytics, check the version compatibility table in the LinkrunnerKit README.
+- Fixed the iOS podspec version, which had drifted to `3.4.0` while `pubspec.yaml` was on `4.0.1`. Both now track the package version.
+
+Note: setting Google Ads consent (`isEEA`, `adUserData`, `adPersonalization`) is not yet exposed through the Dart bridge. Until it is, consent is reported as unknown, which Google treats as "not known" rather than as granted.
+
 ## 4.0.1
 
 - Exposed ad-network attribution fields in attribution data: `adNetworkCampaignId`, `adSetId`, `adSetName`, `adCreativeId`, `adCreativeName`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Bumped native Android SDK to `io.linkrunner:android-sdk:4.1.0` and native iOS SDK to `LinkrunnerKit 4.1.0`.
 - iOS apps now pull `GoogleAdsOnDeviceConversion` transitively and require `-ObjC` and `-lc++` in Other Linker Flags. CocoaPods applies these automatically. If your app also uses Firebase Analytics, check the version compatibility table in the LinkrunnerKit README.
 - Fixed the iOS podspec version, which had drifted to `3.4.0` while `pubspec.yaml` was on `4.0.1`. Both now track the package version.
-- `setConsent(LRConsent(...))` for Google Ads consent: `isEEA`, `adUserData` and `adPersonalization`, each `ConsentStatus.GRANTED` / `.DENIED` / `.UNKNOWN`. Call it before `init` and again whenever your CMP state changes. Omitted signals default to `.UNKNOWN` and are dropped from the payload rather than sent as a denial. Supported on iOS and Android.
+- `setConsent(LRConsent(...))` for Google Ads consent: `isEEA`, `hasConsentForDataUsage` and `hasConsentForAdsPersonalization`, each `ConsentStatus.GRANTED` / `.DENIED` / `.UNKNOWN` (field names match the native iOS and Android SDKs; they are sent as `is_eea`, `ad_user_data` and `ad_personalization`). Call it before `init` and again whenever your CMP state changes. Omitted signals default to `.UNKNOWN` and are dropped from the payload rather than sent as a denial. Supported on iOS and Android.
 
 ## 4.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 - Bumped native Android SDK to `io.linkrunner:android-sdk:4.1.0` and native iOS SDK to `LinkrunnerKit 4.1.0`.
 - iOS apps now pull `GoogleAdsOnDeviceConversion` transitively and require `-ObjC` and `-lc++` in Other Linker Flags. CocoaPods applies these automatically. If your app also uses Firebase Analytics, check the version compatibility table in the LinkrunnerKit README.
 - Fixed the iOS podspec version, which had drifted to `3.4.0` while `pubspec.yaml` was on `4.0.1`. Both now track the package version.
-
-Note: setting Google Ads consent (`isEEA`, `adUserData`, `adPersonalization`) is not yet exposed through the Dart bridge. Until it is, consent is reported as unknown, which Google treats as "not known" rather than as granted.
+- `setConsent(LRConsent(...))` for Google Ads consent: `isEEA`, `adUserData` and `adPersonalization`, each `ConsentStatus.GRANTED` / `.DENIED` / `.UNKNOWN`. Call it before `init` and again whenever your CMP state changes. Omitted signals default to `.UNKNOWN` and are dropped from the payload rather than sent as a denial. Supported on iOS and Android.
 
 ## 4.0.1
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,7 +48,7 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-        implementation 'io.linkrunner:android-sdk:4.0.1'
+        implementation 'io.linkrunner:android-sdk:4.1.0'
     }
 }
 

--- a/android/src/main/kotlin/io/linkrunner/flutter/LinkrunnerPlugin.kt
+++ b/android/src/main/kotlin/io/linkrunner/flutter/LinkrunnerPlugin.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.withContext
 
 // Import the native LinkRunner SDK classes
 import io.linkrunner.sdk.LinkRunner as NativeLinkRunner
+import io.linkrunner.sdk.models.ConsentStatus
+import io.linkrunner.sdk.models.LinkrunnerConsent
 import io.linkrunner.sdk.models.request.UserDataRequest
 import io.linkrunner.sdk.models.request.CapturePaymentRequest
 import io.linkrunner.sdk.models.request.RemovePaymentRequest
@@ -145,6 +147,9 @@ class LinkrunnerPlugin: FlutterPlugin, MethodCallHandler {
             }
             "isAaidCollectionDisabled" -> {
                 isAaidCollectionDisabled(result)
+            }
+            "setConsent" -> {
+                setConsent(call, result)
             }
             "handleDeeplink" -> {
                 val deeplinkUrl = call.argument<String>("deeplinkUrl")
@@ -518,6 +523,27 @@ class LinkrunnerPlugin: FlutterPlugin, MethodCallHandler {
             result.success(null)
         } catch (e: Exception) {
             result.error("SET_DISABLE_AAID_FAILED", e.message, null)
+        }
+    }
+
+    private fun setConsent(call: MethodCall, result: Result) {
+        try {
+            fun status(key: String): ConsentStatus = when (call.argument<String>(key)) {
+                "GRANTED" -> ConsentStatus.GRANTED
+                "DENIED" -> ConsentStatus.DENIED
+                else -> ConsentStatus.UNKNOWN
+            }
+
+            NativeLinkRunner.getInstance().setConsent(
+                LinkrunnerConsent(
+                    isEEA = status("isEEA"),
+                    adUserData = status("adUserData"),
+                    adPersonalization = status("adPersonalization")
+                )
+            )
+            result.success(null)
+        } catch (e: Exception) {
+            result.error("SET_CONSENT_FAILED", e.message, null)
         }
     }
 

--- a/android/src/main/kotlin/io/linkrunner/flutter/LinkrunnerPlugin.kt
+++ b/android/src/main/kotlin/io/linkrunner/flutter/LinkrunnerPlugin.kt
@@ -537,8 +537,8 @@ class LinkrunnerPlugin: FlutterPlugin, MethodCallHandler {
             NativeLinkRunner.getInstance().setConsent(
                 LinkrunnerConsent(
                     isEEA = status("isEEA"),
-                    adUserData = status("adUserData"),
-                    adPersonalization = status("adPersonalization")
+                    hasConsentForDataUsage = status("hasConsentForDataUsage"),
+                    hasConsentForAdsPersonalization = status("hasConsentForAdsPersonalization")
                 )
             )
             result.success(null)

--- a/ios/Classes/SwiftLinkrunnerPlugin.swift
+++ b/ios/Classes/SwiftLinkrunnerPlugin.swift
@@ -99,6 +99,10 @@ public class SwiftLinkrunnerPlugin: NSObject, FlutterPlugin {
                 result(FlutterError(code: "INVALID_ARGUMENT", message: "enabled parameter is required", details: nil))
             }
             
+        case "setConsent":
+            let args = call.arguments as? [String: Any]
+            setConsent(args: args ?? [:], result: result)
+
         case "setPushToken":
             if let args = call.arguments as? [String: Any],
                let pushToken = args["pushToken"] as? String {
@@ -361,6 +365,23 @@ public class SwiftLinkrunnerPlugin: NSObject, FlutterPlugin {
     
     private func enablePIIHashing(enabled: Bool, result: @escaping FlutterResult) {
         LinkrunnerSDK.shared.enablePIIHashing(enabled)
+        result(nil)
+    }
+
+    /// Maps a Dart consent value ("GRANTED"/"DENIED"/"UNKNOWN") to `ConsentStatus`.
+    /// Anything absent or unrecognised becomes `.unknown` rather than a guess.
+    private func consentStatus(from args: [String: Any], key: String) -> ConsentStatus {
+        guard let raw = args[key] as? String else { return .unknown }
+        return ConsentStatus(rawValue: raw.lowercased()) ?? .unknown
+    }
+
+    private func setConsent(args: [String: Any], result: @escaping FlutterResult) {
+        let consent = LinkrunnerConsent(
+            isEEA: consentStatus(from: args, key: "isEEA"),
+            hasConsentForDataUsage: consentStatus(from: args, key: "adUserData"),
+            hasConsentForAdsPersonalization: consentStatus(from: args, key: "adPersonalization")
+        )
+        LinkrunnerSDK.shared.setConsent(consent)
         result(nil)
     }
     

--- a/ios/Classes/SwiftLinkrunnerPlugin.swift
+++ b/ios/Classes/SwiftLinkrunnerPlugin.swift
@@ -378,8 +378,8 @@ public class SwiftLinkrunnerPlugin: NSObject, FlutterPlugin {
     private func setConsent(args: [String: Any], result: @escaping FlutterResult) {
         let consent = LinkrunnerConsent(
             isEEA: consentStatus(from: args, key: "isEEA"),
-            hasConsentForDataUsage: consentStatus(from: args, key: "adUserData"),
-            hasConsentForAdsPersonalization: consentStatus(from: args, key: "adPersonalization")
+            hasConsentForDataUsage: consentStatus(from: args, key: "hasConsentForDataUsage"),
+            hasConsentForAdsPersonalization: consentStatus(from: args, key: "hasConsentForAdsPersonalization")
         )
         LinkrunnerSDK.shared.setConsent(consent)
         result(nil)

--- a/ios/linkrunner.podspec
+++ b/ios/linkrunner.podspec
@@ -1,6 +1,8 @@
 Pod::Spec.new do |s|
   s.name             = 'linkrunner'
-  s.version          = '3.4.0'
+  # Keep in step with pubspec.yaml — these drifted apart previously (pubspec 4.0.1
+  # against podspec 3.4.0).
+  s.version          = '4.1.0'
   s.summary          = 'Flutter Package for linkrunner, track every click, download and dropoff for your app links'
   s.description      = <<-DESC
 Flutter Package for linkrunner.io - Advanced app attribution and link tracking service. 
@@ -13,7 +15,7 @@ user event tracking, and payment analytics for Flutter applications.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'LinkrunnerKit', '4.0.1'
+  s.dependency 'LinkrunnerKit', '4.1.0'
   s.platform = :ios, '15.0'
   s.swift_version = '5.9'
 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -2,6 +2,7 @@ import 'dart:developer' as developer;
 
 import 'package:linkrunner/models/attribution_data.dart';
 import 'package:linkrunner/models/lr_capture_payment.dart';
+import 'package:linkrunner/models/lr_consent.dart';
 import 'package:linkrunner/models/lr_remove_payment.dart';
 import 'package:linkrunner/models/deeplink_data.dart';
 
@@ -278,6 +279,27 @@ class LinkRunner {
         error: e,
       );
       rethrow;
+    }
+  }
+
+  /// Set the Google Ads consent state.
+  ///
+  /// Call it before [init] so the first payload carries the correct state, and call it
+  /// again whenever your CMP state changes. Anything omitted or left
+  /// [ConsentStatus.UNKNOWN] is reported as unknown rather than assumed granted, and is
+  /// dropped from the payload entirely.
+  ///
+  /// Required only if you run Google App Campaigns and have users in the EEA, the UK,
+  /// or Switzerland. Supported on iOS and Android.
+  Future<void> setConsent(LRConsent consent) async {
+    try {
+      await LinkRunnerNativeBridge.setConsent(consent);
+    } catch (e) {
+      developer.log(
+        'Linkrunner: Failed to set consent',
+        name: packageName,
+        error: e,
+      );
     }
   }
 

--- a/lib/linkrunner_native_bridge.dart
+++ b/lib/linkrunner_native_bridge.dart
@@ -2,6 +2,7 @@ import 'dart:developer' as developer;
 import 'package:flutter/services.dart';
 import 'models/attribution_data.dart';
 import 'models/lr_capture_payment.dart';
+import 'models/lr_consent.dart';
 import 'models/lr_remove_payment.dart';
 import 'models/lr_user_data.dart';
 import 'models/deeplink_data.dart';
@@ -305,6 +306,19 @@ class LinkRunnerNativeBridge {
           name: packageName);
     } on PlatformException catch (e) {
       developer.log('Failed to ${disabled ? 'disable' : 'enable'} AAID collection: ${e.message}', 
+          error: e, name: packageName);
+      rethrow;
+    }
+  }
+
+  /// Set the Google Ads consent state, normally from your Consent Management Platform.
+  /// Supported on iOS and Android.
+  static Future<void> setConsent(LRConsent consent) async {
+    try {
+      await _channel.invokeMethod('setConsent', consent.toJSON());
+      developer.log('Consent set successfully', name: packageName);
+    } on PlatformException catch (e) {
+      developer.log('Failed to set consent: ${e.message}',
           error: e, name: packageName);
       rethrow;
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
 export 'linkrunner.dart';
+export 'models/lr_consent.dart';
 export 'models/lr_user_data.dart';
 export 'models/deeplink_data.dart';

--- a/lib/models/lr_consent.dart
+++ b/lib/models/lr_consent.dart
@@ -1,0 +1,35 @@
+/// Tri-state consent signal for Google Ads.
+///
+/// [UNKNOWN] is a distinct state, not a synonym for [DENIED] or [GRANTED]. A signal left
+/// unknown is reported as unknown and dropped from the payload, never sent as a denial.
+enum ConsentStatus { GRANTED, DENIED, UNKNOWN }
+
+/// Google Ads consent state, normally sourced from your Consent Management Platform.
+///
+/// Set it with `linkrunner.setConsent(...)` before `init`, and call it again whenever
+/// your CMP state changes. Defaults to all-[ConsentStatus.UNKNOWN], which is reported
+/// honestly rather than assumed permissive.
+class LRConsent {
+  /// Whether the user is in the European Economic Area, UK or Switzerland.
+  final ConsentStatus isEEA;
+
+  /// Consent to send user data to Google for advertising purposes.
+  final ConsentStatus adUserData;
+
+  /// Consent to use the data for ad personalization.
+  final ConsentStatus adPersonalization;
+
+  const LRConsent({
+    this.isEEA = ConsentStatus.UNKNOWN,
+    this.adUserData = ConsentStatus.UNKNOWN,
+    this.adPersonalization = ConsentStatus.UNKNOWN,
+  });
+
+  Map<String, dynamic> toJSON() {
+    return {
+      'isEEA': isEEA.name,
+      'adUserData': adUserData.name,
+      'adPersonalization': adPersonalization.name,
+    };
+  }
+}

--- a/lib/models/lr_consent.dart
+++ b/lib/models/lr_consent.dart
@@ -14,22 +14,24 @@ class LRConsent {
   final ConsentStatus isEEA;
 
   /// Consent to send user data to Google for advertising purposes.
-  final ConsentStatus adUserData;
+  /// Sent as `ad_user_data`.
+  final ConsentStatus hasConsentForDataUsage;
 
   /// Consent to use the data for ad personalization.
-  final ConsentStatus adPersonalization;
+  /// Sent as `ad_personalization`.
+  final ConsentStatus hasConsentForAdsPersonalization;
 
   const LRConsent({
     this.isEEA = ConsentStatus.UNKNOWN,
-    this.adUserData = ConsentStatus.UNKNOWN,
-    this.adPersonalization = ConsentStatus.UNKNOWN,
+    this.hasConsentForDataUsage = ConsentStatus.UNKNOWN,
+    this.hasConsentForAdsPersonalization = ConsentStatus.UNKNOWN,
   });
 
   Map<String, dynamic> toJSON() {
     return {
       'isEEA': isEEA.name,
-      'adUserData': adUserData.name,
-      'adPersonalization': adPersonalization.name,
+      'hasConsentForDataUsage': hasConsentForDataUsage.name,
+      'hasConsentForAdsPersonalization': hasConsentForAdsPersonalization.name,
     };
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 4.0.1
+version: 4.1.0
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"


### PR DESCRIPTION
Picks up Google Integrated Conversion Measurement support from the native SDKs. **4.0.1 → 4.1.0.**

- `LinkrunnerKit` 4.0.1 → **4.1.0**
- `io.linkrunner:android-sdk` 4.0.1 → **4.1.0**

No Dart API change is needed to adopt ICM — on iOS the native SDK fetches Google's On-Device Measurement value automatically during `initialize` and forwards it to Linkrunner.

## Also fixes: podspec version drift

`ios/linkrunner.podspec` declared `s.version = '3.4.0'` while `pubspec.yaml` was on `4.0.1`. Unlike `rn-linkrunner`, whose podspec reads its version from `package.json`, this one hardcodes it — so the two had silently diverged. Both now say `4.1.0`. Worth considering deriving it from the pubspec so they can't drift again.

## Note on the iOS dependency

Apps now pull `GoogleAdsOnDeviceConversion` (plus `GoogleUtilities` and `nanopb`) **transitively** via CocoaPods — no podspec dependency declaration is needed here, only the version pin. Two things to verify with a real `pod install`:

1. That `-ObjC` and `-lc++` reach the app target. They're set on LinkrunnerKit's `user_target_xcconfig`, which should propagate two levels up, but that hasn't been confirmed empirically.
2. Resolution for apps already using **Firebase Analytics 11.14.0+**, which pulls ODM transitively too. A GA4F version mapping to a different ODM version than `~> 3.6` will fail to resolve — see the compatibility table in the LinkrunnerKit README.

## Known gap

Setting Google Ads consent is **not yet exposed through the Dart bridge**, so consent is reported as `unknown` until it is. Google treats unknown as "not known" rather than granted, so this is safe but incomplete for EEA traffic — and ICM's documented scope *is* the EEA/UK/Switzerland. Worth a follow-up before promoting ICM to Flutter customers with European users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `setConsent(LRConsent)` to configure Google Ads consent from Dart using tri-state values (granted/denied/unknown).
  - iOS (opt-in): enabled Google Integrated Conversion Measurement (ICM) support via On-Device Measurement from the native SDK.
  - Updated native SDK versions to **4.1.0** (Android and iOS).
- **Bug Fixes**
  - Fixed iOS podspec version drift to keep the podspec aligned with the package version.
- **Documentation**
  - Consent values not provided or unrecognized default to **unknown** and are omitted from the payload (not treated as denial).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->