### PR TITLE
fix(ios): unwrap paymentId before calling LinkrunnerKit capturePayment [4.1.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.1
+
+- Fixed a Swift compiler error that broke every iOS build on `4.0.1` through `4.1.0`: the iOS bridge passed an optional `paymentId` into `LinkrunnerKit.capturePayment`, which has required a non-optional `String` since LinkrunnerKit 4.0.0. Builds failed with `Value of optional type 'String?' must be unwrapped to a value of type 'String'` regardless of your Dart code. `paymentId` is now unwrapped at the method-channel boundary. No API change — `LRCapturePayment.paymentId` was already required and non-empty validated, so correct callers are unaffected. Android was never affected.
+
 ## 4.1.0
 
 - Added support for Google Integrated Conversion Measurement (ICM) on iOS. The native SDK fetches Google's On-Device Measurement value during initialization and forwards it to Linkrunner. There is no Dart API to call, but ICM is **opt-in**: it stays inactive until you add Google's SDK to your app (see below). ICM is iOS-only for now; Android is unaffected.

--- a/ios/Classes/SwiftLinkrunnerPlugin.swift
+++ b/ios/Classes/SwiftLinkrunnerPlugin.swift
@@ -69,14 +69,14 @@ public class SwiftLinkrunnerPlugin: NSObject, FlutterPlugin {
         case "capturePayment":
             if let args = call.arguments as? [String: Any],
                let userId = args["userId"] as? String,
-               let amount = args["amount"] as? Double {
-                let paymentId = args["paymentId"] as? String
+               let amount = args["amount"] as? Double,
+               let paymentId = args["paymentId"] as? String, !paymentId.isEmpty {
                 let type = args["type"] as? String ?? "DEFAULT_PAYMENT"
                 let status = args["status"] as? String ?? "PAYMENT_COMPLETED"
                 let eventData = args["eventData"] as? [String: Any]
                 capturePayment(userId: userId, amount: amount, paymentId: paymentId, type: type, status: status, eventData: eventData, result: result)
             } else {
-                result(FlutterError(code: "INVALID_ARGUMENT", message: "User ID and amount are required", details: nil))
+                result(FlutterError(code: "INVALID_ARGUMENT", message: "User ID, amount and payment ID are required", details: nil))
             }
             
         case "removePayment":
@@ -305,7 +305,7 @@ public class SwiftLinkrunnerPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    private func capturePayment(userId: String, amount: Double, paymentId: String?, type: String, status: String, eventData: [String: Any]?, result: @escaping FlutterResult) {
+    private func capturePayment(userId: String, amount: Double, paymentId: String, type: String, status: String, eventData: [String: Any]?, result: @escaping FlutterResult) {
         guard isInitialized else {
             result(FlutterError(code: "NOT_INITIALIZED", message: "SDK not initialized", details: nil))
             return

--- a/ios/linkrunner.podspec
+++ b/ios/linkrunner.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name             = 'linkrunner'
   # Keep in step with pubspec.yaml — these drifted apart previously (pubspec 4.0.1
   # against podspec 3.4.0).
-  s.version          = '4.1.0'
+  s.version          = '4.1.1'
   s.summary          = 'Flutter Package for linkrunner, track every click, download and dropoff for your app links'
   s.description      = <<-DESC
 Flutter Package for linkrunner.io - Advanced app attribution and link tracking service. 

--- a/lib/linkrunner.dart
+++ b/lib/linkrunner.dart
@@ -13,7 +13,7 @@ import 'models/lr_user_data.dart';
 class LinkRunner {
   static final LinkRunner _singleton = LinkRunner._internal();
 
-  final String packageVersion = '4.1.0';
+  final String packageVersion = '4.1.1';
 
   String? token;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linkrunner
 description: "Flutter Package for linkrunner, track every click, download and dropoff for your app links"
-version: 4.1.0
+version: 4.1.1
 homepage: "https://www.linkrunner.io/"
 repository: "https://github.com/RathodDarshil/linkrunner_flutter"
 documentation: "https://github.com/RathodDarshil/linkrunner_flutter#getting-started"


### PR DESCRIPTION
## Summary

Every published `4.x` release of this package fails to compile on iOS. `capturePayment` in the Swift bridge passes an optional `String?` into `LinkrunnerKit`'s `capturePayment`, which has taken a non-optional `String` since LinkrunnerKit 4.0.0.

```
Swift Compiler Error (Xcode): Value of optional type 'String?' must be unwrapped to a value of type 'String'
ios/Classes/SwiftLinkrunnerPlugin.swift:322:31
```

This is unconditional — it fails for every consumer regardless of their Dart code, because it is our own source that does not type-check.

## Root cause

Making `paymentId` mandatory (LIN-1649) needed three changes in this package. Only two were made:

| Layer | Status |
|---|---|
| Dart model — `lib/models/lr_capture_payment.dart` (`final String paymentId`, required, non-empty validated) | done |
| Pod pin — `ios/linkrunner.podspec` bumped to LinkrunnerKit 4.x | done |
| **Swift bridge — `ios/Classes/SwiftLinkrunnerPlugin.swift`** | **missed** |

`ee83237` (the 4.0.0 bump) touched `CHANGELOG.md`, `android/build.gradle`, `ios/linkrunner.podspec`, `lib/linkrunner.dart` and `pubspec.yaml` — the bridge was not among them. The native SDK did nothing wrong; 4.0.0 was an intentional major. `rn-linkrunner` already handles this correctly at `ios/LinkrunnerSDK.swift:134`, which is why React Native builds fine on the same LinkrunnerKit 4.1.0.

## Affected versions

Pins read from the published pub.dev tarballs, not from git:

| linkrunner | published | LinkrunnerKit pin | iOS |
|---|---|---|---|
| 3.10.0 | 2026-06-20 | 3.11.0 | builds |
| 4.0.1 | 2026-07-09 | 4.0.1 | **broken** |
| 4.0.2 | 2026-07-23 | 4.0.1 | **broken** |
| 4.0.3 | 2026-07-28 | 4.0.1 | **broken** |
| 4.1.0 | 2026-07-29 | 4.1.0 | **broken** |

3.10.0 is the last iOS-clean release. Android is unaffected — only the Swift bridge has the mismatch. `4.0.0` was never published to pub.dev, so no consumer can be on it.

## Why it was not caught

Three layers could have caught this; none of them compile Swift against the pinned pod:

1. `flutter pub publish` validates and archives — it never invokes Xcode or `swiftc`. `flutter analyze` is Dart-only.
2. The local playground's `Podfile.lock` was pinned to LinkrunnerKit 3.7.0 (last `pod install`: 2025-12-17), where an optional `paymentId` is legal. Local iOS builds kept compiling the new bridge against the old API.
3. There is no CI that builds iOS.

## The fix

Unwrap at the method-channel boundary and make the private helper take a non-optional `String`, matching the `rn-linkrunner` pattern. Dart already guarantees `paymentId` is present and non-empty, so this is a no-op for correct callers; malformed channel payloads now get an `INVALID_ARGUMENT` `FlutterError` instead of failing to compile.

## Verification

Reproduced and fixed against the real playground (`flutter-linkrunner-sandbox`, `path: ../linkrunner`) with a freshly resolved `Podfile.lock` on LinkrunnerKit 4.1.0.

**Before** — reproduces the reported error at the exact reported line:

```
Failed to build iOS app
Swift Compiler Error (Xcode): Value of optional type 'String?' must be unwrapped to a value of type 'String'
ios/Classes/SwiftLinkrunnerPlugin.swift:322:31
```

**After** — same playground, same pod, unchanged `Podfile.lock`:

```
Building com.example.linkrunnerFlutterPlayground for device (ios-release)...
Running Xcode build...
Xcode build done.                                           25.9s
✓ Built build/ios/iphoneos/Runner.app (16.8MB)
```

`flutter analyze` reports 0 errors (the 15 remaining `info` lints are pre-existing `constant_identifier_names` warnings in `lib/models/lr_consent.dart`, unchanged from 4.1.0).

## Release

Bumps to **4.1.1** across the three places the version lives — `pubspec.yaml`, `ios/linkrunner.podspec` (`s.version`; the `LinkrunnerKit` dependency stays pinned at `4.1.0`) and `LinkRunner.packageVersion` in `lib/linkrunner.dart` — plus a `CHANGELOG.md` entry. This needs to reach pub.dev promptly: until it does, there is no clean customer-side workaround for iOS on 4.x, and every Flutter customer advised to upgrade to 4.1.0 is blocked.

## Follow-ups (not in this PR)

- Add a CI job that runs `flutter build ios --no-codesign` against the playground. A stale `Podfile.lock` hid this for four releases; nothing else in the pipeline type-checks the bridge.
- Audit the Capacitor bridge for the same optional-vs-required drift. `rn-linkrunner` is already correct.
- `LinkrunnerKit 4.0.0` is tagged but absent from CocoaPods trunk (trunk goes `3.11.0 -> 4.0.1 -> 4.1.0`). Harmless today since no published Flutter release pins it, but worth reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS build failures affecting versions 4.0.1–4.1.0.
  * Improved payment capture validation by rejecting missing or empty payment IDs with a clear error.
  * Preserved existing Dart API and Android behavior.

* **Release**
  * Updated the SDK version to 4.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->